### PR TITLE
Add the Azure Boards badge to the README

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,2 +1,3 @@
+[![Board Status](https://dev.azure.com/szilajka/47dca916-c248-4d1f-a169-8f30c47632c7/3c5a13b8-4b1f-4824-84ce-ce97ae64c5af/_apis/work/boardbadge/fee580ae-410c-40f3-950b-921a48b95a90)](https://dev.azure.com/szilajka/47dca916-c248-4d1f-a169-8f30c47632c7/_boards/board/t/3c5a13b8-4b1f-4824-84ce-ce97ae64c5af/Microsoft.RequirementCategory)
 # AnimeBrowser_API
 REST API for Anime Browser, written in C#.


### PR DESCRIPTION
Add the Azure Boards badge for the board used to track the work for this repository. Fixes [AB#6](https://dev.azure.com/szilajka/47dca916-c248-4d1f-a169-8f30c47632c7/_workitems/edit/6). See the [status badge configuration](https://aka.ms/azureboardsgithub-badge) documentation for more information.